### PR TITLE
Replace zero-length arrays with flexible arrays

### DIFF
--- a/libs/exanic/fifo_if.h
+++ b/libs/exanic/fifo_if.h
@@ -142,7 +142,7 @@ struct tx_chunk
      * \note The actual data to transmit may not begin at the beginning of the
      * payload due to padding.  See \ref exanic_payload_padding_bytes.
      */
-    char        payload[0];
+    char        payload[];
 };
 
 /**
@@ -172,7 +172,7 @@ struct tx_payload_metadata
     /**
      * TCP payload starts here
      */
-    char    payload[0];
+    char    payload[];
 };
 
 /**

--- a/libs/exanic/transceiver.h
+++ b/libs/exanic/transceiver.h
@@ -31,7 +31,7 @@ typedef struct
 {
     double                       temp;      /* degrees C */
     unsigned                     num_lanes;
-    struct exanic_port_xcvr_diag lanes[0];  /* per lane diagnostics */
+    struct exanic_port_xcvr_diag lanes[];  /* per lane diagnostics */
 } exanic_xcvr_diag_info_t;
 
 /* port_number: ethernet interface number */


### PR DESCRIPTION
This eliminates undefined behaviour.

It could increase portability, i.e. when the numbers of C compilers that support C99 style flexible arrays outgrows the number of pre-99 C compilers that support GCC style zero-length arrays.

---

NB: Flexible arrays are standardized since C99 whereas
    zero-length arrays are a GCC extension that yield
    undefined behaviour, in general.

See also: https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html