### PR TITLE
Fix compile error on linux 6.6

### DIFF
--- a/modules/exanic/exanic-main.c
+++ b/modules/exanic/exanic-main.c
@@ -1058,7 +1058,7 @@ static int exanic_probe(struct pci_dev *pdev,
         goto err_req_regions;
     }
 
-#if defined(CONFIG_PCIEAER)
+#if defined(CONFIG_PCIEAER) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
     pci_enable_pcie_error_reporting(pdev);
 #endif
     pci_set_master(pdev);
@@ -1883,7 +1883,7 @@ err_interface_ver:
 err_regs_ioremap:
 err_regs_size:
 err_regs_bar_type:
-#if defined(CONFIG_PCIEAER)
+#if defined(CONFIG_PCIEAER) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
     pci_disable_pcie_error_reporting(pdev);
 #endif
     pci_release_regions(pdev);
@@ -2002,7 +2002,7 @@ static void exanic_remove(struct pci_dev *pdev)
     if (exanic->regs_virt != NULL)
         iounmap(exanic->regs_virt);
 
-#if defined(CONFIG_PCIEAER)
+#if defined(CONFIG_PCIEAER) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
     pci_disable_pcie_error_reporting(pdev);
 #endif
     pci_release_regions(pdev);

--- a/modules/exasock/exasock-bonding-sysfs.c
+++ b/modules/exasock/exasock-bonding-sysfs.c
@@ -18,7 +18,12 @@
     && LINUX_VERSION_CODE < KERNEL_VERSION(3, 13, 0) \
     && !__HAS_NETDEV_CLASS_CREATE_FILE_NS
 static const void *
-exabond_get_sysfs_namespace(struct class *cls,
+exabond_get_sysfs_namespace(
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+                            const struct class *cls,
+#else
+                            struct class *cls,
+#endif
                             const struct class_attribute *attr)
 {
     /* This will need to be augmented if we wish to support net namespacing
@@ -29,8 +34,15 @@ exabond_get_sysfs_namespace(struct class *cls,
 #endif
 
 static ssize_t
-exabond_masters_show(struct class *c,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 34)
+exabond_masters_show(
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+                     const struct class *c,
+#else
+                     struct class *c,
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+                     const struct class_attribute *cattr,
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 34)
                      struct class_attribute *cattr,
 #endif
                      char *buf)
@@ -71,8 +83,15 @@ exabond_masters_show(struct class *c,
 }
 
 static ssize_t
-exabond_masters_store(struct class *c,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 34)
+exabond_masters_store(
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+                      const struct class *c,
+#else
+                      struct class *c,
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+                      const struct class_attribute *cattr,
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 34)
                       struct class_attribute *cattr,
 #endif
                       const char *buf, size_t count)

--- a/modules/exasock/exasock-tcp.c
+++ b/modules/exasock/exasock-tcp.c
@@ -1426,8 +1426,10 @@ static void exasock_tcp_dead(struct kref *ref)
 /* need biglock for this one function to avoid race condition */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 36)
 static DECLARE_MUTEX(update_biglock);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 static DEFINE_SEMAPHORE(update_biglock);
+#else
+static DEFINE_SEMAPHORE(update_biglock, 1);
 #endif
 int exasock_tcp_update(struct exasock_tcp *tcp,
                        uint32_t local_addr, uint16_t local_port,


### PR DESCRIPTION
Linux 6.6 has several minor changes which result in compile errors and compile warnings.