### PR TITLE
split hashtables for unicast and multicast lookups

### DIFF
--- a/libs/exasock/socket/send.c
+++ b/libs/exasock/socket/send.c
@@ -620,7 +620,7 @@ sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
 
     TRACE_CALL("sendmmsg");
     TRACE_ARG(INT, sockfd);
-    TRACE_ARG(MMSG_PTR, msgvec, SSIZE_MAX);
+    TRACE_ARG(MMSG_PTR, msgvec, vlen);
     TRACE_ARG(INT, vlen);
     TRACE_LAST_ARG(BITS, flags, msg_flags);
     TRACE_FLUSH();

--- a/libs/exasock/udp.c
+++ b/libs/exasock/udp.c
@@ -16,11 +16,13 @@
 #include "ip.h"
 #include "udp.h"
 
-struct exa_hashtable __exa_udp_sockfds;
+struct exa_hashtable __exa_udp_sockfds_ucast;
+struct exa_hashtable __exa_udp_sockfds_mcast;
 
 __attribute__((constructor))
 void
 __exa_udp_init(void)
 {
-    exa_hashtable_init(&__exa_udp_sockfds);
+    exa_hashtable_init(&__exa_udp_sockfds_ucast);
+    exa_hashtable_init(&__exa_udp_sockfds_mcast);
 }

--- a/libs/exasock/udp.h
+++ b/libs/exasock/udp.h
@@ -1,7 +1,8 @@
 #ifndef EXASOCK_UDP_H
 #define EXASOCK_UDP_H
 
-extern struct exa_hashtable __exa_udp_sockfds;
+extern struct exa_hashtable __exa_udp_sockfds_ucast;
+extern struct exa_hashtable __exa_udp_sockfds_mcast;
 
 struct exa_udp_tx
 {
@@ -103,19 +104,19 @@ exa_udp_validate_csum(char *hdr, char *hdr_end, uint64_t * restrict csum)
 static inline void
 exa_udp_insert(int fd)
 {
-    exa_hashtable_ucast_insert(&__exa_udp_sockfds, fd);
+    exa_hashtable_ucast_insert(&__exa_udp_sockfds_ucast, fd);
 }
 
 static inline void
 exa_udp_remove(int fd)
 {
-    exa_hashtable_ucast_remove(&__exa_udp_sockfds, fd);
+    exa_hashtable_ucast_remove(&__exa_udp_sockfds_ucast, fd);
 }
 
 static inline void
 exa_udp_mcast_insert(int fd, struct exa_mcast_endpoint * restrict mc_ep)
 {
-    exa_hashtable_mcast_insert(&__exa_udp_sockfds, fd, mc_ep);
+    exa_hashtable_mcast_insert(&__exa_udp_sockfds_mcast, fd, mc_ep);
 }
 
 static inline void
@@ -136,7 +137,7 @@ exa_udp_mcast_insert_all(int fd)
 static inline void
 exa_udp_mcast_remove(int fd, struct exa_mcast_endpoint * restrict mc_ep)
 {
-    exa_hashtable_mcast_remove(&__exa_udp_sockfds, fd, mc_ep);
+    exa_hashtable_mcast_remove(&__exa_udp_sockfds_mcast, fd, mc_ep);
 }
 
 static inline void
@@ -158,9 +159,9 @@ static inline int
 exa_udp_lookup(struct exa_endpoint * restrict ep, in_addr_t if_addr)
 {
     if (IN_MULTICAST(ntohl(ep->addr.local)))
-        return exa_hashtable_mcast_lookup(&__exa_udp_sockfds, ep, if_addr);
+        return exa_hashtable_mcast_lookup(&__exa_udp_sockfds_mcast, ep, if_addr);
 
-    return exa_hashtable_ucast_lookup(&__exa_udp_sockfds, ep);
+    return exa_hashtable_ucast_lookup(&__exa_udp_sockfds_ucast, ep);
 }
 
 static inline void


### PR DESCRIPTION
`__exa_udp_sockfds` hashtable may contain two types of objects: `struct exa_socket` for unicast subscriptions and `struct exa_mcast_membership` for multicast ones. Sometimes, due to hash collision, we'd be looking at an object of wrong type, which ends up in a segfault.

